### PR TITLE
Fix: don't show the dashboard image when emacs can't show images

### DIFF
--- a/minimal-dashboard.el
+++ b/minimal-dashboard.el
@@ -247,7 +247,8 @@ FRAME is optional and provided by `window-size-change-functions'."
 
 (defun minimal-dashboard--insert-centered-info ()
   "Insert a centered image and text in the dashboard buffer efficiently."
-  (let* ((image (minimal-dashboard--get-cached-image))
+  (let* ((image (when (display-images-p)
+                  (minimal-dashboard--get-cached-image)))
          (image-size (if image (image-size image) '(0 . 0)))
          (img-width (car image-size))
          (img-height (cdr image-size))


### PR DESCRIPTION
When `display-images-p` return `nil` (like in TUI or emacs-daemon), emacs will report error "Window system frame should be used" and don't show the dashboard buffer because it can't show the dashboard image

So set the dashboard image to `nil` when emacs can't show images